### PR TITLE
chore: Verify and harden qlik-ai-readiness-optimizer tool claims

### DIFF
--- a/official/skills/qlik-ai-readiness-optimizer/CHANGELOG.md
+++ b/official/skills/qlik-ai-readiness-optimizer/CHANGELOG.md
@@ -1,0 +1,37 @@
+# Changelog
+
+All notable changes to the `qlik-ai-readiness-optimizer` skill are documented here. Versioning follows the semver convention described in [official/skills/README.md](../README.md).
+
+---
+
+## 1.1.0 — Minor
+
+**Verification:** Cross-checked every Qlik MCP tool name referenced in this skill. All previously-cited tools (`qlik_search`, `qlik_describe_app`, `qlik_get_fields`, `qlik_list_dimensions`, `qlik_list_measures`, `qlik_create_measure`, `qlik_create_dimension`) are confirmed available — no changes needed there.
+
+**Fixed (stale capability claims):**
+- `references/mcp-capability-matrix.md`: Editing existing Master Items was listed as "⚠️ In Preview (MCP Private Preview Tenant)." This is out of date — `qlik_update_measure` and `qlik_update_dimension` are generally available, not preview-gated. Added them to the matrix as ✅ Available, live immediately.
+- `references/mcp-capability-matrix.md`: Added `qlik_delete_measure` and `qlik_delete_dimension` to the matrix as available tools (the skill still instructs against using them on existing items — see Key Rule #7 — but the matrix should reflect that the capability exists).
+- `SKILL.md`: Updated the Phase 5 "what MCP can vs. cannot do" summary to reflect that editing and deleting existing Master Items is available via MCP (not preview), and to distinguish load script updates (still in preview) from variable definitions and synonym import (not available at all) — the summary previously lumped all three together as unavailable.
+- `references/implementation-guide.md` (Layer 3): Removed the stale claim that "existing Master Items currently require UI editing (MCP edit feature in preview)." Existing Master Items can be regrouped directly via `qlik_update_measure`/`qlik_update_dimension`.
+- `references/implementation-guide.md` (Layer 4): Added `qlik_update_measure`/`qlik_update_dimension` to the tool list so description improvements can be applied directly to existing Master Items instead of only via newly-created ones.
+
+**Fixed (cross-skill ambiguity):** Key Rule #7 read as an unscoped "never delete" policy. Deletion of a genuine duplicate/erroneous Master Item is sometimes the correct action, but it needs its own usage-verification and confirmation workflow — a different concern from this skill's AI-readiness assessment. Reworded to make clear this skill itself never executes deletions and that a delete request should be treated as out of scope here rather than acted on via `qlik_delete_measure`/`qlik_delete_dimension`. Also trimmed the Phase 5 capability summary to a pointer at `references/mcp-capability-matrix.md` instead of restating it, to avoid the two drifting out of sync on a future edit.
+
+**Fixed (internal consistency):**
+- `SKILL.md` Phase 0 / `references/layer-analysis-guide.md` Layer 2: reconciled four different field-count thresholds (>200, >100, 30–60, ≤60) that gave contradictory signals for the same app into one ladder — ≤60 ideal, 61–200 noisy (flagged in Layer 2), >200 structural (flagged in Phase 0).
+- `SKILL.md` Phase 1: "whether Qlik Answers is enabled" had no MCP tool backing it. Added explicit fallback — ask the user, or proceed with the assessment regardless.
+- `SKILL.md` Phase 0 / Phase 6: added guidance for resuming a prior session (re-check existing Master Items before proposing new ones) and for partial IMPLEMENT failures (list succeeded vs. failed changes before continuing).
+- `references/layer-analysis-guide.md` Layer 4: added an explicit callout that every newly-proposed Master Item (in the zero-Master-Items starter-set flow) must include a group, or it reproduces the Layer 3 failure mode on day one.
+- "IST-Zustand" (used unexplained) now reads "IST-Zustand (Current-State) Assessment" on first use.
+
+**Added (new checks, sourced from Qlik's official Qlik Answers documentation):**
+- `references/layer-analysis-guide.md` Layer 4: added a hard-flag check for set identifiers (`{$<...>}`, `{1<...>}`, `{StateName<...>}`) in master measure expressions — Qlik's own documented limitation is that an inner set identifier silently overrides any filter Qlik Answers tries to apply, with no error. This is independent of the existing variable-density complexity gradient.
+- `references/layer-analysis-guide.md` Layer 3: added a distinct "invalid logical model" indexing-failure diagnostic (custom Logical Model logic the indexer rejects), separate from the existing "Logic Disabled" toggle check, with its own fix path (Logical Model → Reset to default).
+- `references/layer-analysis-guide.md` Layer 5: added a check for fiscal/period logic living in a Calendar Period object — not indexed by Qlik Answers, and removed entirely on tenants enabled for the agentic Qlik Answers experience.
+- `references/layer-analysis-guide.md` Layer 1: added the boolean/flag naming convention (`Is Active`, `Has Churned`) to the "what good naming looks like" list.
+- `references/layer-analysis-guide.md` Layer 6: added two synonym anti-patterns — one synonym mapped to multiple fields, and vague relative-ranking terms ("top"/"bottom").
+- `SKILL.md`: added Key Rule #11 (only structured Master Items are indexed; glossary/label-expression/Hierarchy/Behavior/Calendar-Period/Custom-analysis content is not, and is removed on agentic-enabled tenants) and Key Rule #12 (differing answers between users is commonly a section-access difference, not a data-model defect).
+- `SKILL.md` Phase 6: added a note that Logical Model changes can take up to 24 hours to reindex in Qlik Answers, separate from the app-engine "live immediately" behavior already documented.
+- `SKILL.md`: clarified that Knowledge Base is a property of a multi-app Assistant, not a single-app Qlik Answers session.
+
+**Not added:** an entity-context-prefix renaming convention for ID/key fields was considered (raised by an initial research pass) but does not match Qlik's own guidance, which recommends hiding primary/foreign keys outright — matching what this skill's Layer 2 already does. Discarded rather than adding an unverified convention.

--- a/official/skills/qlik-ai-readiness-optimizer/SKILL.md
+++ b/official/skills/qlik-ai-readiness-optimizer/SKILL.md
@@ -17,7 +17,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: JoshQlikDesign
-  version: 1.0.0
+  version: 1.1.0
   tags:
     - qlik
     - ai-readiness
@@ -45,7 +45,7 @@ The Qlik Engine world is deterministic and technical. The AI world is semantic a
 | 5 | Date Fields + AutoCalendar | 🟠 High | Time-based question accuracy |
 | 6 | Synonyms / Vocabulary | 🟡 Medium | Business jargon, multilingual support |
 
-Note: Knowledge Base is not part of the readiness score. It is an optional enhancement configured via the Qlik Answers admin UI.
+Note: Knowledge Base is not part of the readiness score. A Knowledge Base is a property of an **Assistant** (which combines one structured app with unstructured document sources), not of a single-app Qlik Answers session — if the user's context is "Qlik Answers on this one app" rather than a multi-app Assistant, Knowledge Base configuration doesn't apply and can be skipped without qualification.
 
 ## Workflow Overview
 
@@ -83,10 +83,12 @@ Attempt a lightweight MCP call (e.g., `qlik_search` or `qlik_describe_app`) to c
 Use `qlik_describe_app` and `qlik_get_fields` to check for:
 - **Synthetic keys** (`$Syn 1`, `$Syn 2`, etc.) — table join problems
 - **Circular references** or link tables suggesting unresolved many-to-many relationships
-- **Extreme field counts** (>200 visible fields) — may need model restructuring first
+- **Extreme field counts** (>200 visible fields) — structural, flag here before a full Layer 2 pass; see [references/layer-analysis-guide.md](references/layer-analysis-guide.md) Layer 2 for the full threshold ladder (≤60 ideal, 61–200 noisy, >200 structural)
 - **Zero tables or zero fields** — app may be empty or misconfigured
 
 **If critical structural issues are found:** present as a blocking warning, explain they undermine AI optimization, and let the user decide whether to proceed.
+
+**If the user is resuming a previous optimization session:** re-run a quick check (`qlik_list_measures`/`qlik_list_dimensions`) before proposing new Master Items, to avoid duplicating items already created in an earlier session.
 
 ---
 
@@ -96,11 +98,11 @@ Ask the user which app to analyze if not already specified.
 
 Use `qlik_search` (query: name of the app) and `qlik_describe_app` (app_id).
 
-Collect: App ID, App Name, number of tables, fields, sheets, and whether Qlik Answers is enabled.
+Collect: App ID, App Name, number of tables, fields, and sheets via `qlik_describe_app`. No Qlik MCP tool currently reports whether Qlik Answers is enabled for an app — ask the user directly, or note it as unknown and proceed with the technical assessment regardless (the 6-layer model applies whether or not Answers is currently turned on).
 
 ---
 
-## Phase 2: ANALYZE — IST-Zustand Assessment
+## Phase 2: ANALYZE — IST-Zustand (Current-State) Assessment
 
 Run a comprehensive analysis across all 6 layers. Batch tool calls where possible.
 
@@ -168,22 +170,18 @@ For detailed per-layer implementation steps, output templates, and copy-paste sc
 
 For the MCP capability matrix and reload requirements, see [references/mcp-capability-matrix.md](references/mcp-capability-matrix.md).
 
-**Summary of what MCP can vs. cannot do:**
-- ✅ Create new Master Measures/Dimensions (with groups + descriptions) — live immediately
-- ⚠️ Edit existing Master Items — in preview
-- ⚠️ Update load script — in preview, requires reload
-- ❌ Retrieve variable definitions — not available
-- ❌ Import synonyms/vocabulary — must be done via UI
+**Summary of what MCP can vs. cannot do:** create, edit, and delete Master Measures/Dimensions live immediately; load script updates are in preview; variable definitions and synonym import are not available at all. See [references/mcp-capability-matrix.md](references/mcp-capability-matrix.md) for the full tool-by-tool table.
 
 ---
 
 ## Phase 6: VERIFY
 
 After completing each layer:
-- Confirm what was changed
+- Confirm what was changed. If any approved change failed to apply (rate limit, validation error, stale app state), explicitly list which ones succeeded vs. failed before asking to continue — don't let a partial failure silently roll into the next layer's confirmation.
 - Note what required manual steps (and provide exact instructions)
 - Update the AI Readiness Score
 - Remind user about reload requirements for load script changes
+- If the change touched the Logical Model (grouping, or a fix to an "invalid logical model" indexing error), tell the user Qlik Answers can take up to 24 hours to reindex — this is separate from the app-engine "live immediately" behavior, and testing in Answers right away may still show stale results even though the fix applied correctly
 - Ask if user wants to continue to next layer
 
 See [references/mcp-capability-matrix.md](references/mcp-capability-matrix.md) for reload requirement details.
@@ -198,10 +196,12 @@ See [references/mcp-capability-matrix.md](references/mcp-capability-matrix.md) f
 4. **Don't give the AI more fields than necessary** — less noise = fewer errors
 5. **Descriptions are primary** — the AI uses them to decide which metric to use
 6. **High variable density in expressions reduces AI resolution confidence** — enrich descriptions or inline where feasible
-7. **Never delete existing Master Items** — it breaks dashboards. Create new ones alongside.
+7. **This skill never deletes existing Master Items** — its job is to assess and improve AI readiness, not to manage master-item lifecycle, so the IMPLEMENT phase only creates new items and edits/groups existing ones. Deletion is a real, sometimes-correct action (e.g. a true duplicate created in error), but it requires its own usage-verification and confirmation workflow — treat any delete request as out of scope for this skill and hand it off to whatever governs master-item lifecycle in your environment, rather than calling `qlik_delete_measure`/`qlik_delete_dimension` here.
 8. **Always get user confirmation** before making changes
 9. **MCP cannot retrieve variable definitions** — ask the user for resolved values if inlining
 10. **Load script changes require an app reload** — Master Item changes via MCP are live immediately
+11. **Only structured, named Master Items are indexed by Qlik Answers** — business glossary definitions, label expressions on Master Items, and content inside Packages, Hierarchies, Behaviors, Calendar Periods, Custom analysis, and Example questions are not indexed. On tenants enabled for the agentic Qlik Answers experience, those unindexed feature types are removed entirely, not just skipped — treat logic living in any of them as something that needs to be re-expressed as a real field or Master Item, not left in place.
+12. **If two users get different answers to the same question, check section access first** — Qlik Answers automatically inherits and enforces existing section access / row-level security with no extra configuration, so differing permissions are a common, expected cause of differing answers. Don't assume a data-model defect until access parity is ruled out.
 
 ## Communication Style
 

--- a/official/skills/qlik-ai-readiness-optimizer/references/implementation-guide.md
+++ b/official/skills/qlik-ai-readiness-optimizer/references/implementation-guide.md
@@ -60,10 +60,15 @@ Note: MCP cannot change field visibility directly. Requires load script or Logic
 
 ```
 Action: Create groups and assign fields/Master Items
-Tools: qlik_create_dimension (with group tag), qlik_list_measures, qlik_list_dimensions
-Note: Group assignment is done by tagging Master Items when creating/updating them.
-New Master Items can be created with groups via MCP.
-Existing Master Items currently require UI editing (MCP edit feature in preview).
+Tools: qlik_create_dimension (with group tag), qlik_update_dimension, qlik_update_measure,
+       qlik_list_measures, qlik_list_dimensions
+Note: Group assignment is done by tagging Master Items when creating or updating them.
+New Master Items can be created with groups via MCP (qlik_create_measure/qlik_create_dimension).
+Existing Master Items can also be regrouped directly via MCP using qlik_update_measure /
+qlik_update_dimension — no UI editing required.
+
+Every proposed Master Item must include a group — an ungrouped new item recreates the
+Layer 3 failure mode (Key Rule #1), whether it's newly created or being regrouped.
 ```
 
 ---
@@ -72,7 +77,8 @@ Existing Master Items currently require UI editing (MCP edit feature in preview)
 
 ```
 Action: Optimize Master Items with semantic descriptions; assess expression complexity
-Tools: qlik_create_measure, qlik_create_dimension, qlik_list_measures, qlik_list_dimensions
+Tools: qlik_create_measure, qlik_create_dimension, qlik_update_measure, qlik_update_dimension,
+       qlik_list_measures, qlik_list_dimensions
 ```
 
 ### Output to provide
@@ -80,6 +86,7 @@ Tools: qlik_create_measure, qlik_create_dimension, qlik_list_measures, qlik_list
 1. A Master Item optimization report showing each item's description quality, expression complexity, and group status
 2. For items with 🔴 Missing or 🟠 Minimal descriptions: generate rich descriptions following the template:
    `"[Metric Name]: [What it calculates]. [What it excludes]. [When to use vs. similar metrics]. Also known as: [synonyms]."`
+   Apply the improved description to the existing item directly via `qlik_update_measure`/`qlik_update_dimension` — no need to recreate it as a new Master Item.
 3. For items with 🔴 High complexity expressions (especially heavy variable density):
    - Identify which expressions have the highest variable density and recommend enriching descriptions to explain the full resolved computation
    - For highest-impact Master Items: suggest simplified/inlined expression alternatives where feasible

--- a/official/skills/qlik-ai-readiness-optimizer/references/layer-analysis-guide.md
+++ b/official/skills/qlik-ai-readiness-optimizer/references/layer-analysis-guide.md
@@ -17,6 +17,7 @@ Detailed checklists, severity classifications, scoring rubrics, and example outp
 - **Domain context where ambiguous**: `Order Date` not just `Date`, `Product Category` not just `Category`
 - **No ETL/developer prefixes**: no `dim_`, `fact_`, `stg_`, `tbl_` prefixes
 - **No system suffixes**: no `_ID`, `_KEY`, `_FK`, `_SK` unless intentionally visible
+- **Boolean/flag fields use proposition prefixes**: `Is Active`, `Has Churned` — not `Active`, `ChurnFlag`, or bare `Flag1`
 
 ### Severity tiers — classify every field
 
@@ -91,8 +92,10 @@ The AI sees every visible field as a potential candidate for answering questions
 - Calculated/derived fields where purpose is unclear without context
 - Fields in a language the user doesn't ask questions in
 
-**⚠️ Structural red flags**
-- Total visible field count > 100 → model is too noisy for optimal AI use
+**⚠️ Structural red flags — field-count threshold ladder** (same ladder used in Phase 0 PREFLIGHT, this is the finer-grained pass):
+- ≤ 60 visible fields → ideal
+- 61–200 visible fields → noisy, flag in this layer's scoring
+- > 200 visible fields → structural; if not already flagged in Phase 0 PREFLIGHT, flag it now
 - Synthetic keys present → data model needs restructuring (flag, don't just hide)
 - Multiple tables with overlapping field names → ambiguity risk for AI
 
@@ -151,6 +154,11 @@ Check for:
 **⚠️ Blocking check: Logic Disabled**
 - If "Logic Disabled" is set in the Logical Model → ALL Master Items are invisible regardless of grouping. Warn user to check this in the Qlik Hub UI (cannot be detected via MCP).
 
+**⚠️ Distinct blocking check: "invalid logical model" indexing failure**
+- Different from Logic Disabled — this is Logic *Enabled* but with custom business logic that Qlik Answers' indexer rejects, surfacing as an "invalid logical model" error or an indexing process that hangs indefinitely when the user tries to enable Qlik Answers on the app.
+- If the user reports "Answers won't turn on for this app" or indexing hangs, ask whether they see this specific error before assuming a Layer 3 grouping problem — the fix is different: Logical Model → Overview → "Reset to default," re-enable for Answers, reload, retest.
+- After any Logical Model fix (this one or a grouping fix), reindexing can take up to 24 hours — don't conclude a fix failed just because Answers hasn't picked it up yet in the same session (see Phase 6 VERIFY).
+
 ### Scoring rubric
 
 | Check | Weight | Scoring |
@@ -185,7 +193,7 @@ If `qlik_list_measures` and `qlik_list_dimensions` both return empty:
 2. **Shift to a creation workflow**:
    - Analyze fields from Layers 1/2 to identify likely business measures and dimensions
    - Propose a starter set of 10-15 Master Items (5-8 measures, 5-7 dimensions)
-   - For each: include name, expression, description (rich format), and suggested group
+   - For each: include name, expression, description (rich format), and suggested group — every proposed item must include a group, or it recreates the Layer 3 failure mode (Key Rule #1) on day one
    - Present for user approval before creating anything
 3. **Set expectations**: "This app has no Master Items, which means Qlik Answers has nothing to work with."
 
@@ -212,6 +220,12 @@ A rich description follows this pattern:
 
 💡 A single variable is fine. The optimization opportunity arises with 3+ variables, nested chains, or variables referencing other variables. Enrich descriptions to explain the full resolved logic.
 
+**C2. Set identifiers / alternate states — hard flag, independent of C's gradient**
+
+Qlik's documented Qlik Answers limitations: if a master measure's expression contains an inner set identifier — `{$<...>}` (current selection state), `{1<...>}` (full dataset), or `{StateName<...>}` (an alternate state) — Qlik Engine's set-analysis precedence rules make that inner identifier override any filter Qlik Answers tries to apply on top of it. This fails silently: no error, no warning, just a wrong-looking result. Example: `Sum({$<Car_Type={'SUV'}>}Price)` asked with a "Brand" filter returns all-brands SUV revenue, not the filtered brand's SUV revenue.
+
+This is categorically different from the variable-density gradient in C — a single, otherwise-simple set-analysis expression is enough to break filtering. Any master measure whose expression contains `{$<`, `{1<`, or `{`+any state name+`<` should be flagged 🔴 regardless of its C tier, with a note explaining the silent-failure risk and a recommendation to remove the inner set identifier (or restructure the measure so filtering happens outside the expression).
+
 **D. Group assignment:** Cross-reference with Layer 3.
 
 ### Scoring rubric
@@ -219,7 +233,7 @@ A rich description follows this pattern:
 | Sub-dimension | Weight | Scoring |
 |---------------|--------|---------|
 | Description quality | 40% | Missing=0.0, Minimal=0.4, Rich=1.0 |
-| Expression complexity | 35% | Simple=1.0, Moderate=0.5, High=0.2 |
+| Expression complexity | 35% | Simple=1.0, Moderate=0.5, High=0.2, **contains a set identifier/alternate state=0.0 regardless of tier** |
 | Group assigned | 25% | Yes=1.0, No=0.0 |
 
 **Layer 4 Score** = weighted average across all Master Items × 100
@@ -256,6 +270,7 @@ A rich description follows this pattern:
 **C. Fiscal year and custom calendar handling**
 - Non-January fiscal year? Is there a fiscal year field or fiscal quarter mapping?
 - Dual calendar needs (calendar year + fiscal year)?
+- ⚠️ **Where does the fiscal logic actually live?** Qlik Answers does not index content inside a Calendar Period object — if fiscal quarters/periods are defined there instead of as a real field or Master Dimension, they are invisible to Answers no matter how well the rest of the model is prepared. Worse, Calendar Period objects (along with Hierarchies, Behaviors, and Custom analysis) are removed entirely once a tenant is enabled for the agentic Qlik Answers experience — so this isn't just an indexing gap, it can be a breaking change for that tenant. If fiscal logic lives in a Calendar Period object, recommend re-expressing it as a loaded field or Master Dimension.
 
 **D. Relative date fields**
 - Relative time markers ("Current Month", "YTD", "Rolling 12 Months")?
@@ -301,6 +316,11 @@ A rich description follows this pattern:
 - App used by people who ask questions in different languages?
 - Synonyms defined in all relevant languages?
 - Field names in one language but users ask in another?
+
+### Anti-patterns to flag, not just coverage gaps
+
+- **One synonym mapped to multiple fields** (e.g. "sales" assigned to two different measures) — ambiguous, forces Qlik Answers to guess which one the user meant.
+- **Vague relative-ranking terms** ("top", "bottom") — these can be interpreted multiple, conflicting ways and should not be used as synonyms.
 
 ### Prioritization guidance
 

--- a/official/skills/qlik-ai-readiness-optimizer/references/mcp-capability-matrix.md
+++ b/official/skills/qlik-ai-readiness-optimizer/references/mcp-capability-matrix.md
@@ -14,8 +14,11 @@ MCP tool availability and reload requirements. Referenced from the main [SKILL.m
 | List Master Dimensions | `qlik_list_dimensions` | ✅ Available | — |
 | Create new Master Measure (with group + description) | `qlik_create_measure` | ✅ Available | ❌ No — live immediately |
 | Create new Master Dimension (with group + description) | `qlik_create_dimension` | ✅ Available | ❌ No — live immediately |
+| Edit existing Master Measure | `qlik_update_measure` | ✅ Available | ❌ No — live immediately |
+| Edit existing Master Dimension | `qlik_update_dimension` | ✅ Available | ❌ No — live immediately |
+| Delete Master Measure | `qlik_delete_measure` | ✅ Available (this skill does not call it — see Key Rule #7) | ❌ No — live immediately |
+| Delete Master Dimension | `qlik_delete_dimension` | ✅ Available (this skill does not call it — see Key Rule #7) | ❌ No — live immediately |
 | Retrieve variable definitions | — | ❌ Not available | — |
-| Edit existing Master Item | — | ⚠️ In Preview (MCP Private Preview Tenant) | ❌ No |
 | Update load script | — | ⚠️ In Preview | ✅ Yes — reload after editing |
 | Import synonyms/vocabulary | — | ❌ Must be done via UI | ❌ No — live after UI save |
 | Set field visibility (hidden) | — | ⚠️ Via load script `%` prefix (manual) | ✅ Yes — reload after editing |
@@ -31,6 +34,7 @@ Not all changes are live immediately. Clearly tell the user what requires a relo
 | New Master Measure/Dimension created via MCP | Immediately | ❌ No |
 | Master Item description updated via MCP | Immediately | ❌ No |
 | Master Item group assignment via MCP | Immediately | ❌ No |
+| Master Item edited or deleted via MCP (`qlik_update_measure`/`qlik_update_dimension`/`qlik_delete_measure`/`qlik_delete_dimension`) | Immediately | ❌ No |
 | Load script field rename (`AS` alias) | After reload | ✅ Yes |
 | Load script field hide (`%` prefix) | After reload | ✅ Yes |
 | Load script date conversion | After reload | ✅ Yes |


### PR DESCRIPTION
## Summary
- Verifies every Qlik MCP tool name this skill cites, fixes stale "in preview" capability claims, and reconciles the Key Rule 7 conflict with master-item deletion policy.
- Reconciles internal inconsistencies (field-count thresholds, undocumented "Answers enabled" check, IST-Zustand jargon).
- Adds new checks sourced from Qlik's official Qlik Answers documentation: set-identifier/alternate-state hard-flag in master measures (Layer 4), a distinct "invalid logical model" indexing failure (Layer 3), Calendar Period object visibility (Layer 5), boolean naming convention (Layer 1), synonym anti-patterns (Layer 6), and two new Key Rules plus a reindex-lag note.
- `qlik_get_data_model` and `qlik_get_field_states` were deliberately left out of the matrix — they exist in the `qlik-mcp` server source but are not in the production GA tool catalogue.

## Test plan
- [x] `skills-ref validate official/skills/qlik-ai-readiness-optimizer/` passes
- [x] Maintainer review of new Layer 3/4/5 checks against Qlik Answers docs