### PR TITLE
Add qlik-load-script community skill

### DIFF
--- a/community/skills/README.md
+++ b/community/skills/README.md
@@ -10,7 +10,7 @@ Community skills are **opt-in**. They are never silently enabled in a Qlik envir
 
 | Skill | Author | Description |
 |---|---|---|
-| *(be the first to contribute)* | | |
+| [qlik-load-script](qlik-load-script/) | [nabeel-oz](https://github.com/nabeel-oz) | Lightweight skill for coding agents (Claude Code, Cursor, etc.) to write, complete, and extend Qlik Sense load scripts (.qvs) — general authoring plus data prep for ML-ready datasets with Qlik Predict |
 
 ---
 

--- a/community/skills/qlik-load-script/SKILL.md
+++ b/community/skills/qlik-load-script/SKILL.md
@@ -240,6 +240,18 @@ When the user provides a starting script or prompt:
 
 ---
 
+## Example
+
+**User prompt:**
+> "I have `lib://DataFiles/transactions.qvd` (one row per transaction: `CustomerID`, `TransactionDate`, `Amount`, `ProductCategory`, `Returned`) and `lib://DataFiles/customers.qvd` (one row per customer: `CustomerID`, `SignupDate`, `Region`). Build an ML prep script that predicts whether a customer cancels (`CancellationDate` is populated) in the next 90 days. Output training/testing QVDs."
+
+**Expected response:**
+1. State back the task: target = binary flag derived from `CancellationDate` (leaky field to drop after deriving the target), grain = one row per customer, source = the two QVDs above.
+2. Write a script (following the [Script Template](#script-template)) that: loads both QVDs, aggregates `transactions` to customer grain (`TxnCount`, `TotalSpend`, `AvgSpend`, `Recency_Days`, `Count(DISTINCT ProductCategory)`, return rate — see [Feature Engineering Patterns](references/syntax-and-patterns.md#13-feature-engineering-patterns)), joins onto `customers`, derives `Churn_Flag` from `CancellationDate` then drops `CancellationDate` itself (leakage), applies the random 80/20 split from [Train/Test split approaches](#train-test-split-approaches), and stores `training_data.qvd` / `testing_data.qvd`.
+3. Flag any uncertain function calls with `// TODO: verify`, and call out the leakage check (`CancellationDate` removed) explicitly after the script.
+
+---
+
 ## Reference
 
 - **Syntax & patterns reference:** [references/syntax-and-patterns.md](references/syntax-and-patterns.md) — full Qlik load script syntax, common pitfalls, and feature engineering code patterns. **Read this before writing any script.**

--- a/community/skills/qlik-load-script/SKILL.md
+++ b/community/skills/qlik-load-script/SKILL.md
@@ -1,0 +1,249 @@
+---
+name: qlik-load-script
+description: "Write, complete, or extend Qlik Sense load scripts (.qvs) for data preparation. Primary use case is preparing flat datasets for ML experiments with Qlik Predict — engineering features, handling train/test splits, and outputting QVD files. Also covers general Qlik load script authoring: completing scripts from starting code, comments, or prompts. Use this skill whenever the user mentions Qlik load script, .qvs files, Qlik data load, QVD output, data preparation for Qlik Predict, or asks for help writing or fixing Qlik script syntax. Also trigger when the user provides a Qlik load script and asks for modifications, extensions, feature engineering, or data transformations. Even if the user just pastes Qlik script code and asks a question about it, use this skill."
+license: Apache-2.0
+metadata:
+  author: nabeel-oz
+  version: 1.0.0
+  tags:
+    - qlik
+    - load-script
+    - qvs
+    - etl
+    - data-preparation
+    - qlik-predict
+    - claude-code
+    - cursor
+    - coding-agent
+---
+
+# Qlik Load Script Generator
+
+## Overview
+
+You are writing **Qlik Sense load script** (.qvs files) for data preparation. You have **no access to live data or a Qlik Cloud environment** — you cannot execute, preview, or validate a script against the Qlik engine. Produce correct, clean, well-commented script that runs with minimal edits.
+
+**Built for coding agents.** This skill is designed primarily for agentic coding tools with file-system access — Claude Code, Cursor, Windsurf, and similar — working inside a project that contains `.qvs` files:
+- Read the existing script(s) from disk (via your file-read tool) before editing.
+- Edit or create the `.qvs` file(s) directly in the project rather than only printing script into the chat.
+- Preserve the surrounding project structure (other tabs, connections, file layout) exactly as found, except where the task asks you to change it.
+
+If you are running in a chat-only environment with no file access (e.g. a plain web chat), fall back to outputting complete script blocks for the user to copy and paste — see [Response Format](#response-format).
+
+**Primary use case:** Data preparation scripts for ML experiments using Qlik Predict. The user provides a starting script with base data. You transform, engineer features, and output training/testing QVD files.
+
+**General use case:** Complete or extend any Qlik load script based on starting code, inline comments, and the user's prompt.
+
+## Critical Rules
+
+1. **This is Qlik load script, not SQL.** The syntax resembles SQL but differs in important ways. When unsure, read [references/syntax-and-patterns.md](references/syntax-and-patterns.md) and consult: https://help.qlik.com/en-US/cloud-services/Subsystems/Hub/Content/Sense_Hub/LoadData/script-syntax-functions.htm
+2. **Never invent functions.** If you are not confident a built-in function exists, say so and suggest an alternative you are confident about.
+3. **No execution.** You cannot run or test the script against Qlik Cloud, regardless of environment. Flag anything you are uncertain about with a `// TODO: verify` comment so the user can check.
+4. **Preserve the user's starting script.** Do not rewrite or restructure parts of the script the user did not ask you to change.
+5. **Output complete, runnable script.** Do not output partial snippets with "..." elisions unless the user explicitly asks for a diff. When you have file access, write the complete section back to the `.qvs` file; when outputting to chat, the user is copy-pasting into the Qlik Cloud script editor.
+
+**Before writing any Qlik script**, read [references/syntax-and-patterns.md](references/syntax-and-patterns.md) for the full syntax reference, common pitfalls, and code patterns. This is essential — Qlik syntax has many subtle differences from SQL that cause silent bugs if you rely on SQL intuition.
+
+---
+
+## ML Data Preparation Guidelines
+
+### Common data sources
+Starting scripts typically load from **CSV** or **QVD** files via `lib://` connections. Match the source format and lib path used in the starting script. When loading CSV files, always specify the format explicitly:
+```qlik
+FROM [lib://DataFiles/data.csv] (txt, codepage is utf8, embedded labels, delimiter is ',');
+```
+
+### Feature engineering philosophy
+Apply your **data science and ML knowledge** to engineer features that are likely to have genuine predictive signal for the specific use case. Aim for impact over exhaustiveness — a focused set of well-reasoned features is better than a sprawling feature matrix that adds noise. Consider domain context, known drivers from the literature, and the business logic behind the prediction task when choosing what to derive.
+
+### Output structure for Qlik Predict
+Qlik Predict expects a **flat, single-table dataset**:
+- One row = one observation at the defined grain (e.g., one customer, one loan, one month-region).
+- One column = the **target** (what you are predicting).
+- Remaining columns = **features** (inputs to the model).
+- Supported output: QVD (preferred), CSV, XLSX, Parquet.
+
+### Target column requirements
+| Experiment Type | Target Requirement |
+|---|---|
+| Binary classification | Exactly 2 unique values (e.g., `Yes`/`No`, `1`/`0`, `Churn`/`Active`) |
+| Multiclass classification | 3–10 unique categorical values |
+| Regression | Numeric with >10 unique values |
+| Time series | Numeric target + date index column + optional group columns (max 2) |
+
+### Feature count and field retention guidance
+- **Aim for impactful features** without overcomplicating the feature matrix. Focus on features with clear predictive signal rather than exhaustively deriving every possible combination. Use your data science and ML knowledge to prioritise features that are likely to matter for the specific use case.
+- **Always retain ID/key fields** (e.g., CustomerID, LoanID, PolicyNumber). These are not used as features during training, but they are essential for linking predictions back to the original data after model deployment. Qlik Predict will ignore high-cardinality identifiers automatically — keeping them in the dataset does no harm.
+- Remove fields that are direct derivatives or consequences of the target (leakage).
+
+### Date format convention
+Date fields should be stored in **YYYY-MM-DD** format (ISO 8601) for reliability across Qlik environments. Qlik Predict automatically derives date dimensions (year, month, day of week, quarter, etc.) from fields it profiles as dates, so you generally do **not** need to manually decompose dates into separate year/month/day columns. Focus manual date engineering on features Qlik Predict cannot auto-derive: date differences, durations, and domain-specific periods.
+
+```qlik
+// Format dates as YYYY-MM-DD for reliable interpretation
+Date(Date#(RawDateField, 'DD/MM/YYYY'), 'YYYY-MM-DD') as EventDate,
+// Manual date engineering — only for features Qlik Predict won't auto-derive
+Today() - Date#(RawDateField, 'DD/MM/YYYY') as DaysSinceEvent
+```
+
+### Train/Test split approaches
+
+The split produces a **held-out validation set** that simulates real-world unseen data after model training and deployment — critical for POC credibility. Qlik Predict handles its own internal cross-validation and evaluation metrics during training; the test set you create here is a separate, external validation asset. Choose the approach that fits the use case.
+
+**Approach 1 — Random split (default for most use cases)**
+```qlik
+// Random 80/20 split with fixed seed for reproducibility
+LET vSeed = 42;
+
+WithSplit:
+LOAD
+    *,
+    If(Rand($(vSeed)) <= 0.8, 'Train', 'Test') as SplitFlag
+RESIDENT FinalFeatures;
+
+DROP TABLE FinalFeatures;
+
+// Store separately
+Training:
+NoConcatenate
+LOAD * RESIDENT WithSplit WHERE SplitFlag = 'Train';
+DROP FIELD SplitFlag FROM Training;
+STORE Training INTO [lib://DataFiles/training_data.qvd] (qvd);
+DROP TABLE Training;
+
+Testing:
+NoConcatenate
+LOAD * RESIDENT WithSplit WHERE SplitFlag = 'Test';
+DROP FIELD SplitFlag FROM Testing;
+STORE Testing INTO [lib://DataFiles/testing_data.qvd] (qvd);
+DROP TABLE Testing;
+
+DROP TABLE WithSplit;
+```
+
+**Approach 2 — Time-based split (when temporal ordering matters)**
+
+Use this when the prediction task is inherently time-dependent (e.g., forecasting, next-month churn, seasonal risk). Splitting on time prevents future data from leaking into the training set and better simulates production conditions.
+```qlik
+// Split on a date threshold — all data before cutoff = Train, after = Test
+LET vCutoffDate = Num(MakeDate(2025, 1, 1));
+
+Training:
+NoConcatenate
+LOAD * RESIDENT FinalFeatures
+WHERE ObservationDate < $(vCutoffDate);
+STORE Training INTO [lib://DataFiles/training_data.qvd] (qvd);
+DROP TABLE Training;
+
+Testing:
+NoConcatenate
+LOAD * RESIDENT FinalFeatures
+WHERE ObservationDate >= $(vCutoffDate);
+STORE Testing INTO [lib://DataFiles/testing_data.qvd] (qvd);
+DROP TABLE Testing;
+
+DROP TABLE FinalFeatures;
+```
+
+### Target leakage checklist
+Before finalizing any ML prep script, verify:
+- [ ] No field is a direct consequence of the target (e.g., `Cancellation_Date` when predicting churn).
+- [ ] No field is populated only after the event being predicted.
+- [ ] Lag/window features exclude the current row (offsets start at -1 or earlier).
+- [ ] No aggregation inadvertently includes future data.
+- [ ] Ask: **"Would I know this value at the moment I need to make the prediction?"**
+
+### Class imbalance (binary classification)
+If the minority class is <20% of rows, flag this in a comment and suggest:
+1. Redefining the target window (broaden the positive class definition).
+2. Undersampling the majority class via `Rand()`.
+3. Oversampling the minority class via `CONCATENATE`.
+4. Letting Qlik Predict's intelligent optimization handle auto-balancing (works for moderate imbalance, 5–20%).
+
+### Final cleanup checklist
+Before outputting the final script:
+- [ ] All temporary/intermediate tables are `DROP`ped.
+- [ ] ID/key fields are retained for linking predictions back to source data. Only drop temporary helper columns.
+- [ ] The target column is clearly identified in a comment.
+- [ ] Field names are descriptive (no raw abbreviations unless domain-standard).
+- [ ] Null handling is explicit for critical fields.
+- [ ] STORE path defaults to `lib://DataFiles/...` unless the starting script uses a different lib connection — match it.
+- [ ] Script includes a header comment block with: purpose, target field, grain, date generated.
+
+---
+
+## Script Template
+
+When generating a new ML prep script from scratch, use this structure:
+
+```qlik
+///$tab Main
+/**
+ * ML Data Preparation Script
+ * Purpose:     [describe the prediction task]
+ * Target:      [field name] ([binary/regression/multiclass/time series])
+ * Grain:       One row per [entity]
+ * Generated:   [date]
+ * Source data: [describe inputs]
+ */
+
+///$tab Config
+// ============================================================
+// CONFIGURATION
+// ============================================================
+SET vOutputPath = 'lib://DataFiles';  // Default — use the lib path from the starting script if different
+LET vToday = Today();
+// LET vCutoffDate = Num(MakeDate(2025, 1, 1));  // Uncomment for time-based split
+
+///$tab Source Data
+// ============================================================
+// LOAD SOURCE DATA
+// ============================================================
+// [Load base tables from QVDs or other sources]
+
+///$tab Feature Engineering
+// ============================================================
+// FEATURE ENGINEERING
+// ============================================================
+// [Aggregation, derived fields, joins, enrichment]
+
+///$tab Final Assembly
+// ============================================================
+// ASSEMBLE FINAL DATASET
+// ============================================================
+// [Combine all features into one flat table]
+// [Drop helper tables]
+// [Drop leaky or unnecessary fields]
+
+///$tab Output
+// ============================================================
+// STORE OUTPUT
+// ============================================================
+// [Train/test split if applicable]
+// [STORE to QVD]
+// [DROP final tables]
+```
+
+> **Note on `///$tab` comments:** These are Qlik script section markers. They create named tabs in the Qlik Cloud script editor. Use them to organize long scripts into logical sections.
+
+---
+
+## Response Format
+
+When the user provides a starting script or prompt:
+
+1. **Understand the task.** State back the prediction target, grain, and key transformations needed. Ask clarifying questions if the intent is ambiguous.
+2. **Write the script.** If you have file access (Claude Code, Cursor, etc.), edit or create the `.qvs` file(s) directly. Otherwise, output complete, runnable Qlik load script sections in the chat. Use comments liberally.
+3. **Flag uncertainties.** Mark anything you are not 100% sure about with `// TODO: verify — [reason]`.
+4. **Explain non-obvious logic.** After the script block, briefly explain any complex Window() calls, tricky joins, or domain-specific choices.
+5. **Suggest improvements.** If you see opportunities for additional features, better handling of nulls/outliers, or potential leakage risks, mention them after the main output.
+
+---
+
+## Reference
+
+- **Syntax & patterns reference:** [references/syntax-and-patterns.md](references/syntax-and-patterns.md) — full Qlik load script syntax, common pitfalls, and feature engineering code patterns. **Read this before writing any script.**
+- **Qlik Script Syntax & Functions:** https://help.qlik.com/en-US/cloud-services/Subsystems/Hub/Content/Sense_Hub/LoadData/script-syntax-functions.htm
+- **Qlik Predict documentation:** https://help.qlik.com/en-US/cloud-services/Subsystems/Hub/Content/Sense_Hub/AutoML/home-automl.htm
+- **Window function reference:** https://help.qlik.com/en-US/cloud-services/Subsystems/Hub/Content/Sense_Hub/LoadData/window-functions.htm

--- a/community/skills/qlik-load-script/SKILL.md
+++ b/community/skills/qlik-load-script/SKILL.md
@@ -93,13 +93,12 @@ The split produces a **held-out validation set** that simulates real-world unsee
 
 **Approach 1 — Random split (default for most use cases)**
 ```qlik
-// Random 80/20 split with fixed seed for reproducibility
-LET vSeed = 42;
+// Random 80/20 split (non-deterministic across reloads)
 
 WithSplit:
 LOAD
     *,
-    If(Rand($(vSeed)) <= 0.8, 'Train', 'Test') as SplitFlag
+    If(Rand() <= 0.8, 'Train', 'Test') as SplitFlag
 RESIDENT FinalFeatures;
 
 DROP TABLE FinalFeatures;

--- a/community/skills/qlik-load-script/references/syntax-and-patterns.md
+++ b/community/skills/qlik-load-script/references/syntax-and-patterns.md
@@ -110,7 +110,7 @@ LOAD * RESIDENT SomeTable;
 | **Conditional** | `If(condition, then, else)`, `Pick()`, `Match()`, `MixMatch()`, `WildMatch()` |
 | **String** | `Len()`, `Left()`, `Right()`, `Mid()`, `SubField()`, `Replace()`, `Upper()`, `Lower()`, `Trim()`, `PurgeChar()`, `KeepChar()`, `TextBetween()` |
 | **Date** | `Today()`, `Now()`, `Year()`, `Month()`, `Day()`, `WeekDay()`, `Week()`, `Date()`, `Date#()`, `Num()`, `Interval()`, `AddMonths()`, `YearStart()`, `MonthStart()` |
-| **Null/Missing** | `IsNull()`, `Null()`, `If(Len(Field)=0, ...)`, `Alt()`, `Coalesce()` |
+| **Null/Missing** | `IsNull()`, `Null()`, `If(Len(Field)=0, ...)`, `Alt()` (SQL `COALESCE()` equivalent — returns the first non-null argument) |
 | **Math** | `Ceil()`, `Floor()`, `Round()`, `Fabs()`, `Log()`, `Sqrt()`, `Mod()`, `Div()`, `RangeMin()`, `RangeMax()`, `RangeAvg()`, `RangeSum()` |
 | **Type** | `IsNum()`, `IsText()`, `Num()`, `Text()`, `Num#()`, `Date#()`, `Money#()` |
 | **Inter-record** | `Previous()`, `Peek()`, `FieldValue()`, `FieldValueCount()` |

--- a/community/skills/qlik-load-script/references/syntax-and-patterns.md
+++ b/community/skills/qlik-load-script/references/syntax-and-patterns.md
@@ -1,0 +1,310 @@
+# Qlik Load Script — Syntax & Patterns Reference
+
+## Table of Contents
+1. Statements and Structure
+2. LOAD Statement Patterns
+3. JOINs
+4. CONCATENATE
+5. WHERE, GROUP BY, ORDER BY
+6. Key Functions
+7. Variables and Dollar-Sign Expansion
+8. DROP TABLE / DROP FIELD
+9. STORE to QVD
+10. QUALIFY / UNQUALIFY
+11. Mapping Tables
+12. Common Pitfalls
+13. Feature Engineering Patterns
+
+---
+
+## 1. Statements and Structure
+- Scripts execute **top-to-bottom, sequentially**. Table creation order matters.
+- Every `LOAD` or `SELECT` statement creates (or concatenates into) a **named table**.
+- Statements are terminated with **semicolons**.
+- Comments: `//` for single-line, `/* ... */` for multi-line, `REM ...;` for remark statements.
+- Use `SET` or `LET` for variables. `SET` assigns a string literal; `LET` evaluates the expression.
+
+---
+
+## 2. LOAD Statement Patterns
+
+```qlik
+// Load from file
+TableName:
+LOAD
+    Field1,
+    Field2,
+    Expression as DerivedField
+FROM [lib://DataFiles/filename.qvd] (qvd);
+
+// Load from another table already in memory
+DerivedTable:
+LOAD
+    Field1,
+    Field2,
+    Expression as NewField
+RESIDENT ExistingTable;
+
+// Load with a preceding LOAD (stacked — outer LOAD transforms the inner LOAD's output)
+FinalTable:
+LOAD
+    *,
+    Field1 + Field2 as Combined
+;
+LOAD
+    FieldA as Field1,
+    FieldB as Field2
+FROM [lib://DataFiles/source.csv] (txt, codepage is utf8, embedded labels, delimiter is ',');
+```
+
+---
+
+## 3. JOINs
+- Joins are written as a prefix to a `LOAD` or `SELECT` statement, not inline.
+- The join target is the table being joined **into** (named in parentheses).
+```qlik
+// LEFT JOIN — adds columns from RHS to LHS, matching on shared field names
+LEFT JOIN (MainTable)
+LOAD
+    KeyField,
+    EnrichmentField1,
+    EnrichmentField2
+FROM [lib://DataFiles/lookup.qvd] (qvd);
+
+// INNER JOIN
+INNER JOIN (MainTable)
+LOAD * RESIDENT OtherTable;
+```
+- **Automatic key detection:** Qlik joins on all fields that share the same name in both tables. There is no `ON` clause. Rename fields if you need to control the join key.
+- Join types: `JOIN` (inner), `LEFT JOIN`, `RIGHT JOIN`, `OUTER JOIN`.
+
+---
+
+## 4. CONCATENATE
+- Appends rows from one load into an existing table (union).
+```qlik
+CONCATENATE (TargetTable)
+LOAD * RESIDENT SourceTable;
+```
+- Without the explicit table name, Qlik auto-concatenates if field names match a prior table — **this is a common source of bugs.** Use `NoConcatenate` to prevent it.
+```qlik
+NoConcatenate
+NewTable:
+LOAD * RESIDENT SomeTable;
+```
+
+---
+
+## 5. WHERE, GROUP BY, ORDER BY
+- `WHERE` filters rows. Uses Qlik expression syntax (not SQL).
+- `GROUP BY` works with aggregation functions in the LOAD. **Every non-aggregated field must appear in GROUP BY.**
+- `ORDER BY` sorts rows within a LOAD (rarely needed; mainly for Window functions or specific output ordering).
+
+---
+
+## 6. Key Functions
+
+| Category | Functions |
+|---|---|
+| **Aggregation** | `Sum()`, `Count()`, `Avg()`, `Min()`, `Max()`, `Count(DISTINCT ...)` |
+| **Conditional** | `If(condition, then, else)`, `Pick()`, `Match()`, `MixMatch()`, `WildMatch()` |
+| **String** | `Len()`, `Left()`, `Right()`, `Mid()`, `SubField()`, `Replace()`, `Upper()`, `Lower()`, `Trim()`, `PurgeChar()`, `KeepChar()`, `TextBetween()` |
+| **Date** | `Today()`, `Now()`, `Year()`, `Month()`, `Day()`, `WeekDay()`, `Week()`, `Date()`, `Date#()`, `Num()`, `Interval()`, `AddMonths()`, `YearStart()`, `MonthStart()` |
+| **Null/Missing** | `IsNull()`, `Null()`, `If(Len(Field)=0, ...)`, `Alt()`, `Coalesce()` |
+| **Math** | `Ceil()`, `Floor()`, `Round()`, `Fabs()`, `Log()`, `Sqrt()`, `Mod()`, `Div()`, `RangeMin()`, `RangeMax()`, `RangeAvg()`, `RangeSum()` |
+| **Type** | `IsNum()`, `IsText()`, `Num()`, `Text()`, `Num#()`, `Date#()`, `Money#()` |
+| **Inter-record** | `Previous()`, `Peek()`, `FieldValue()`, `FieldValueCount()` |
+| **Window** | `Window(aggr_expr, partition, sort_type, sort_expr, filter_expr, start, end)` |
+| **Mapping** | `ApplyMap('MapName', LookupField, DefaultValue)`, `MapSubstring()` |
+| **File** | `QvdCreateTime()`, `FileSize()`, `FileTime()` |
+
+---
+
+## 7. Variables and Dollar-Sign Expansion
+
+```qlik
+SET vMyVar = Hello;           // vMyVar contains the string 'Hello'
+LET vToday = Today();         // vToday contains today's date (evaluated)
+LET vRowCount = NoOfRows('TableName');
+
+// Dollar-sign expansion substitutes variable values into expressions
+LOAD * RESIDENT MyTable WHERE Amount > $(vThreshold);
+```
+- `$(vVar)` expands before the expression is evaluated.
+- For string values in WHERE clauses: `WHERE Field = '$(vStringVar)'`
+- Dollar-sign expansion happens at parse time, not runtime. Be careful with timing.
+
+---
+
+## 8. DROP TABLE / DROP FIELD
+
+```qlik
+DROP TABLE TempTable;
+DROP TABLES Table1, Table2, Table3;
+DROP FIELD FieldName FROM TableName;
+DROP FIELDS Field1, Field2;
+```
+
+---
+
+## 9. STORE to QVD
+
+```qlik
+STORE TableName INTO [lib://DataFiles/output.qvd] (qvd);
+STORE TableName INTO [lib://DataFiles/output.csv] (txt);
+```
+
+---
+
+## 10. QUALIFY / UNQUALIFY
+- `QUALIFY *;` prefixes all field names with `TableName.FieldName` to prevent automatic associations.
+- `UNQUALIFY *;` turns it off.
+- Use sparingly and deliberately. Usually it is better to rename fields explicitly.
+
+---
+
+## 11. Mapping Tables
+
+```qlik
+MapRegion:
+MAPPING LOAD
+    StateCode,
+    RegionName
+FROM [lib://DataFiles/region_mapping.csv] (txt, ...);
+
+// Usage:
+MainTable:
+LOAD
+    *,
+    ApplyMap('MapRegion', StateCode, 'Unknown') as Region
+RESIDENT RawData;
+```
+
+---
+
+## 12. Common Pitfalls
+
+| Pitfall | What happens | How to avoid |
+|---|---|---|
+| **Missing semicolons** | Parser error, often cryptic | Every statement ends with `;` |
+| **Auto-concatenation** | Two tables with matching fields silently merge into one | Use `NoConcatenate` or rename fields |
+| **Join key mismatch** | JOIN matches on ALL shared field names, not just the one you intend | Rename unintended shared fields before joining |
+| **GROUP BY mismatch** | Non-aggregated fields missing from GROUP BY cause errors | List every non-aggregated field in GROUP BY |
+| **Dual values confusion** | A field can have both a text and numeric representation (dual). Aggregations on text-stored numbers fail silently | Use `Num()`, `Num#()`, or `Text()` to enforce type |
+| **Null vs empty string** | `IsNull()` only catches true nulls, not empty strings. `Len(Field)=0` catches empty strings | Use `If(Len(Trim(Field))=0 or IsNull(Field), ...)` for both |
+| **RESIDENT after DROP** | Referencing a table you already dropped | Track table lifecycle carefully |
+| **Preceding LOAD field visibility** | Outer (preceding) LOAD can only see fields from the inner LOAD, not from other tables | When in doubt, use RESIDENT instead |
+| **Dollar-sign expansion timing** | `$(vVar)` evaluates at parse time, not row-by-row | For row-level logic use `Peek()` or field references, not variables |
+| **Date interpretation** | Dates loaded from CSV may be strings, not Qlik serial dates | Use `Date#(Field, 'format')` to parse, then format as YYYY-MM-DD: `Date(Date#(Field, 'DD/MM/YYYY'), 'YYYY-MM-DD')` |
+| **Window() misuse** | Forgetting partition or sort fields gives nonsensical results | Always specify partition and sort. Test with small data |
+
+---
+
+## 13. Feature Engineering Patterns
+
+### Aggregation to grain (transactional → one row per entity)
+```qlik
+CustomerFeatures:
+LOAD
+    CustomerID,
+    Count(TransactionID) as TxnCount,
+    Sum(Amount) as TotalSpend,
+    Avg(Amount) as AvgSpend,
+    Max(Amount) as MaxSpend,
+    Min(TransactionDate) as FirstPurchaseDate,
+    Max(TransactionDate) as LastPurchaseDate,
+    Count(DISTINCT ProductCategory) as UniqueCategories
+RESIDENT Transactions
+GROUP BY CustomerID;
+```
+
+### Lag features via Window()
+```qlik
+WithLags:
+LOAD
+    *,
+    Window(Sum(Sales), Region, 'ASC', YearMonth, , -1, -1) as Sales_Lag1,
+    Window(Sum(Sales), Region, 'ASC', YearMonth, , -3, -1) as Sales_RollingAvg3
+RESIDENT MonthlySales;
+```
+> Window offsets: `-1, -1` = previous row. `-3, -1` = rolling 3-period window. Current row is excluded to prevent leakage.
+
+### Ratios and proportions
+```qlik
+LOAD
+    *,
+    If(TotalTransactions > 0, Returns / TotalTransactions, 0) as ReturnRate,
+    If(TotalSpend > 0, ElectronicsSpend / TotalSpend, 0) as ElectronicsShare
+RESIDENT CustomerFeatures;
+```
+
+### Binary flags
+```qlik
+LOAD
+    *,
+    If(DaysSinceLastPurchase > 90, 1, 0) as IsInactive,
+    If(AvgSpend > 500, 1, 0) as IsHighSpender
+RESIDENT CustomerFeatures;
+```
+
+### Binning / bucketing
+```qlik
+LOAD
+    *,
+    If(Age < 25, 'Under25',
+       If(Age < 40, '25-39',
+          If(Age < 55, '40-54', '55+'))) as AgeBucket,
+    Class(TotalSpend, 100) as SpendBucket
+RESIDENT CustomerFeatures;
+```
+
+### Date formatting
+```qlik
+LOAD
+    *,
+    // Format dates as YYYY-MM-DD for reliable interpretation
+    Date(Date#(RawDateField, 'DD/MM/YYYY'), 'YYYY-MM-DD') as EventDate,
+    // Manual date engineering — only for features Qlik Predict won't auto-derive
+    Today() - Date#(RawDateField, 'DD/MM/YYYY') as DaysSinceEvent,
+    If(WeekDay(Date#(RawDateField, 'DD/MM/YYYY')) >= 5, 1, 0) as IsWeekend
+RESIDENT RawData;
+```
+
+### RFM (Recency, Frequency, Monetary)
+```qlik
+RFM:
+LOAD
+    CustomerID,
+    Today() - Max(TransactionDate) as Recency_Days,
+    Count(TransactionID) as Frequency,
+    Sum(Amount) as Monetary
+RESIDENT Transactions
+GROUP BY CustomerID;
+```
+
+### Joining enrichment data
+```qlik
+LEFT JOIN (MainTable)
+LOAD
+    KeyField,
+    EnrichmentField1,
+    EnrichmentField2
+FROM [lib://DataFiles/lookup.qvd] (qvd);
+```
+
+### Mapping table for categorical encoding
+```qlik
+RiskMap:
+MAPPING LOAD * INLINE [
+    Category, RiskScore
+    Low, 1
+    Medium, 2
+    High, 3
+    Critical, 4
+];
+
+LOAD
+    *,
+    ApplyMap('RiskMap', RiskCategory, 0) as RiskScore_Numeric
+RESIDENT MainTable;
+```


### PR DESCRIPTION
## Summary

Adds `qlik-load-script`, a lightweight community skill for **coding agents**
(Claude Code, Cursor, and similar tools with file-system access) that write,
complete, and extend Qlik Sense load scripts (`.qvs` files).

- **General authoring**: complete or extend any load script from starting
  code, inline comments, or a prompt — with a syntax/pitfalls reference
  (`references/syntax-and-patterns.md`) covering the ways Qlik script
  silently diverges from SQL (auto-concatenation, join-key matching on all
  shared field names, dual values, dollar-sign expansion timing, etc.).
- **Primary use case**: data modelling and preparation of flat, ML-ready
  datasets for [Qlik Predict](https://help.qlik.com/en-US/cloud-services/Subsystems/Hub/Content/Sense_Hub/AutoML/home-automl.htm)
  — feature engineering, leakage checks, train/test split patterns, and QVD
  output.

It's designed primarily to run where the agent has file access and can
read/edit `.qvs` files directly in a project, falling back to
copy-pasteable script blocks in chat-only environments. No MCP server,
scripts, or network calls required.

Personal repo (source of truth): https://github.com/nabeel-oz/qlik-load-script
(MIT-licensed; this PR's copy is Apache-2.0 per community-tier convention).

## Differentiation

The one existing community skill, `qlik-ai-readiness-optimizer`, assesses
AI/analytics maturity — a different domain. No other skill here authors
Qlik load script or preps datasets for Qlik Predict.

## Example

> "Here's my load script loading `Customers.qvd` and `Transactions.qvd`.
> Add RFM features and a stratified 80/20 train/test split, then store both
> as QVDs for a Qlik Predict churn experiment."

The agent reads the pasted/existing script, engineers the features using
the patterns in the reference doc, and writes the complete script back
(editing the `.qvs` file directly if it has file access).

## Test plan

- [x] `node scripts/validate-skill-spec.mjs` — `ok — 0 errors, 0 warning(s)`
- [x] `node scripts/validate-claude-plugin.mjs` — `ok — 0 errors, 0 warning(s)`
- [x] Secrets/plaintext-HTTP self-check (`grep -rniE "api[_-]?key|secret|token|password|http://"`) — no matches
- [x] Confirmed no scripts and no outbound network calls in the skill
- [ ] `skills-ref validate` — not run locally (`uv`/`uvx` not installed in this environment); not yet wired into CI per CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)