### PR TITLE
docs: align official and community skills READMEs

### DIFF
--- a/community/skills/README.md
+++ b/community/skills/README.md
@@ -12,6 +12,7 @@ Community skills are **opt-in**. They are never silently enabled in a Qlik envir
 |---|---|---|
 | [qlik-sense-app-analysis](qlik-sense-app-analysis/) | [nabeel-oz](https://github.com/nabeel-oz) | Explore, analyze, visualize, and govern Qlik Sense apps and Qlik Cloud analytics content (master items, business glossary, data products) via the Qlik MCP server. |
 | [qlik-load-script](qlik-load-script/) | [nabeel-oz](https://github.com/nabeel-oz) | Lightweight skill for coding agents (Claude Code, Cursor, etc.) to write, complete, and extend Qlik Sense load scripts (.qvs) — general authoring plus data prep for ML-ready datasets with Qlik Predict |
+| [qlik-talk-to-data](qlik-talk-to-data/) | [ybl74](https://github.com/ybl74) | Answers analytical questions against a Qlik Cloud app via the Qlik MCP server — read-only exploration and ephemeral analysis, with no persistent changes except an explicitly requested bookmark. |
 
 ---
 
@@ -23,6 +24,9 @@ npx skills add qlik-oss/agentic-skills --skill your-skill-name
 
 # Install to a specific agent
 npx skills add qlik-oss/agentic-skills --skill your-skill-name -a claude-code
+
+# Install to all agents
+npx skills add qlik-oss/agentic-skills --skill your-skill-name --agent '*'
 ```
 
 ---
@@ -89,7 +93,7 @@ uvx --from git+https://github.com/agentskills/agentskills#subdirectory=skills-re
 
 ### 5. Open a pull request
 
-Fork the repo, add your skill under `/community/skills/`, and open a PR using the provided template. The automated CI pipeline runs spec validation and security scanning. A maintainer will review within 5 business days.
+Fork the repo, add your skill under `/community/skills/`, and open a PR using the provided template. The automated CI pipeline runs spec validation; a maintainer runs a local security scan before merging. A maintainer will review within 5 business days.
 
 ---
 
@@ -104,6 +108,12 @@ Community skills do not need to meet the same bar as official skills, but they m
 - Include at least one realistic usage example
 
 Skills that fail the automated checks or violate the security rules will not be merged.
+
+---
+
+## Versioning
+
+Community skills aren't held to the same versioning rigor as [official skills](../../official/skills/README.md#versioning), but you should still bump `metadata.version` using semver whenever you change a skill you maintain: patch for wording fixes, minor for new steps or reference files, major for breaking changes to behavior or trigger phrases. This isn't enforced by CI, but it helps users and maintainers tell what changed.
 
 ---
 

--- a/official/skills/README.md
+++ b/official/skills/README.md
@@ -6,7 +6,7 @@ Skills in this directory are owned and maintained by Qlik engineering. They repr
 
 ## Who maintains these skills
 
-Official skills are authored and reviewed by members of the `@qlik-oss/agentic-skills-official-maintainers` team. Every change goes through a pull request, passes automated spec validation and security scanning, and requires at least one team member review before merging.
+Official skills are authored and reviewed by members of the `@qlik-oss/agentic-skills-official-maintainers` team. Every change goes through a pull request, passes automated spec validation in CI, is checked with a local security scan before merge, and requires at least one team member review before merging.
 
 If you find a bug or want to suggest an improvement to an official skill, open a GitHub issue — do not open a PR directly against this directory unless you are a member of `@qlik-oss/agentic-skills-official-maintainers`.
 
@@ -14,7 +14,12 @@ If you find a bug or want to suggest an improvement to an official skill, open a
 
 ## Available skills
 
-Skills in this directory are listed by their folder name. Each folder contains a `SKILL.md` with the full description and trigger phrases.
+| Skill | Author | Description |
+|---|---|---|
+| [qlik-ai-readiness-optimizer](qlik-ai-readiness-optimizer/) | JoshQlikDesign | Analyzes a Qlik app via MCP and optimizes it for AI use (Qlik Answers and Qlik MCP) using a 5-Layer Model. |
+| [qlik-automation-builder](qlik-automation-builder/) | yeshQ | Builds Qlik Automate automations — translates natural-language requests into automation workspace JSON and can create, update, or delete automations via qlik-mcp. |
+
+Each folder contains a `SKILL.md` with the full description and trigger phrases.
 
 ---
 
@@ -26,6 +31,9 @@ npx skills add qlik-oss/agentic-skills --skill '*' --agent '*'
 
 # Install a specific official skill
 npx skills add qlik-oss/agentic-skills --skill <skill-name>
+
+# Install to a specific agent
+npx skills add qlik-oss/agentic-skills --skill <skill-name> -a claude-code
 ```
 
 ---
@@ -60,7 +68,7 @@ Official skills follow semantic versioning:
 - **Minor** (`1.x.0`) — new steps, new reference files, expanded coverage
 - **Major** (`x.0.0`) — breaking changes to skill behavior, renamed trigger phrases, structural rewrites
 
-The version is set in the `metadata.version` field of `SKILL.md`. Changelog entries are maintained in each skill's directory as `CHANGELOG.md`.
+The version is set in the `metadata.version` field of `SKILL.md`. Skills are encouraged to track changelog entries in a `CHANGELOG.md` in their own directory; this is not yet enforced for existing skills.
 
 ---
 
@@ -72,4 +80,10 @@ To propose a change to an official skill:
 2. A member of `@qlik-oss/agentic-skills-official-maintainers` will triage and, if approved, either implement it or invite you to submit a PR.
 3. PRs against `/official/` from non-team members will be closed and converted to issues.
 
-For net-new workflows that don't fit an existing skill, consider contributing to [`/community/skills/`](../../community/skills/) first. Community skills can be promoted to official if they see significant adoption and meet quality standards.
+For net-new workflows that don't fit an existing skill, consider contributing to [`/community/skills/`](../../community/skills/) first. Community skills can be promoted to official if they see significant adoption and meet quality standards — see [Getting promoted to official](../../community/skills/README.md#getting-promoted-to-official) for the criteria.
+
+---
+
+## Security
+
+Because official skills go through mandatory maintainer review and a security scan before merging, they carry a lower risk profile than community skills. If you discover a security vulnerability in an official skill, do not open a public issue. Email `security@qlik.com` with the subject line `[Agent Skills] Vulnerability Report` — see the [Security section of CONTRIBUTING.md](../../CONTRIBUTING.md#security) for full details.


### PR DESCRIPTION
## Summary
- Corrects the "security scanning" claim in both READMEs — per `CONTRIBUTING.md`, CI only runs spec validation; security scanning is a manual/local step before merge, not wired into CI.
- Adds parity sections that existed on one side but not the other:
  - `official/skills/README.md`: adds a "Browse skills" table (skill/author/description), an `-a claude-code` install example, a `## Security` section, and a link to community's promotion criteria.
  - `community/skills/README.md`: adds a `## Versioning` section (semver guidance, non-enforced) and an `--agent '*'` install example.
- Softens the official README's `CHANGELOG.md` claim to "encouraged, not yet enforced" — neither existing official skill has one.
- Adds `qlik-talk-to-data` to the community "Browse skills" table — it existed in the directory but wasn't listed.

## Test plan
- [x] Verified all internal links/anchors in every `README.md` resolve to existing files/headings.
- [x] Verified all external links (agentskills.io, skills.sh, github.com/anthropics/skills, qlik.dev, contributor profiles) return HTTP 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)